### PR TITLE
🐛(settings) fix settings following changes on Richie master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ stop: ## stop the development server
 
 # == Django tasks
 demo-site:  ## create a demo site
+	@$(MANAGE) flush
 	@$(MANAGE) create_demo_site
 	@${MAKE} search-index;
 .PHONY: demo-site

--- a/src/backend/funmooc/settings.py
+++ b/src/backend/funmooc/settings.py
@@ -216,7 +216,7 @@ class Base(DRFMixin, ElasticSearchMixin, Configuration):
     )
 
     # Group to add plugin to placeholder "Content"
-    FUN_PLUGINS_GROUP = "Fun Plugins"
+    RICHIE_PLUGINS_GROUP = "Fun Plugins"
 
     LANGUAGE_CODE = "en"
 
@@ -276,10 +276,9 @@ class Base(DRFMixin, ElasticSearchMixin, Configuration):
         ("courses/cms/blogpost_detail.html", _("Blog post page")),
         ("courses/cms/person_detail.html", _("Person page")),
         ("search/search.html", _("Search")),
-        ("richie/fullwidth.html", "Fullwidth"),
         ("richie/child_pages_list.html", _("List of child pages")),
         ("richie/homepage.html", _("Homepage")),
-        ("richie/single-column.html", _("Single column")),
+        ("richie/single_column.html", _("Single column")),
     )
     CMS_PERMISSION = True
 


### PR DESCRIPTION
## Purpose

Some settings have changed on Richie master that are breaking this repository (breaking changes are not taken care of as we are not yet in v1.0.0).

## Proposal

Apply the same changes as what was done in Richie:

- the `FUN_PLUGINS_GROUP` setting was renamed to `RICHIE_PLUGINS_GROUP`
- the `single-column.html` template was renamed to `single_column.html`
- the `fullwidth.html` template is kept only as a base template but can't be used anymore to build pages,
- the `create_demo_site` does not do its database partial cleaning anymore. We now rely on the `flush` Django command.
