### PR TITLE
⬆️(core) upgrade to richie 1.0.0-beta.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Define CDN_DOMAIN settings with cloudfront domain value.
 
+### Changed
+
+- Upgrade richie to 1.0.0-beta.9
+
 ## [0.2.0] - 2019-05-07
 
 ### Changed

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,5 +6,5 @@ django-storages==1.6.3
 dockerflow==2018.4.0
 gunicorn==19.9.0
 psycopg2-binary==2.7.7
-richie==1.0.0b8
+richie==1.0.0b9
 sentry-sdk==0.7.9

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -31,6 +31,6 @@
     "node-sass": "4.11.0",
     "nodemon": "1.18.10",
     "prettier": "1.16.4",
-    "richie-education": "1.0.0-beta.8"
+    "richie-education": "1.0.0-beta.9"
   }
 }

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -880,10 +880,12 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-hoist-non-react-statics@^2.5.5:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
-  integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
+hoist-non-react-statics@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
+  integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
+  dependencies:
+    react-is "^16.7.0"
 
 hosted-git-info@^2.1.4:
   version "2.7.1"
@@ -1889,10 +1891,10 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-query-string@6.4.2:
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.4.2.tgz#8be1dbd105306aebf86022144f575a29d516b713"
-  integrity sha512-DfJqAen17LfLA3rQ+H5S4uXphrF+ANU1lT2ijds4V/Tj4gZxA3gx5/tg1bz7kYCmwna7LyJNCYqO7jNRzo3aLw==
+query-string@6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.5.0.tgz#2e1a70125af01f6f04573692d02c09302a1d8bfc"
+  integrity sha512-TYC4hDjZSvVxLMEucDMySkuAS9UIzSbAiYGyA9GWCjLKB8fQpviFbjd20fD7uejCDxZS+ftSdBKE6DS+xucJFg==
   dependencies:
     decode-uri-component "^0.2.0"
     split-on-first "^1.0.0"
@@ -1936,18 +1938,18 @@ react-dom@16.8.6:
     prop-types "^15.6.2"
     scheduler "^0.13.6"
 
-react-intl@2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-2.8.0.tgz#20b0c1f01d1292427768aa8ec9e51ab7e36503ba"
-  integrity sha512-1cSasNkHxZOXYYhms9Q1tSEWF8AWZQNq3nPLB/j8mYV0ZTSt2DhGQXHfKrKQMu4cgj9J1Crqg7xFPICTBgzqtQ==
+react-intl@2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-2.9.0.tgz#c97c5d17d4718f1575fdbd5a769f96018a3b1843"
+  integrity sha512-27jnDlb/d2A7mSJwrbOBnUgD+rPep+abmoJE511Tf8BnoONIAUehy/U1zZCHGO17mnOwMWxqN4qC0nW11cD6rA==
   dependencies:
-    hoist-non-react-statics "^2.5.5"
+    hoist-non-react-statics "^3.3.0"
     intl-format-cache "^2.0.5"
     intl-messageformat "^2.1.0"
     intl-relativeformat "^2.1.0"
     invariant "^2.1.1"
 
-react-is@^16.8.1:
+react-is@^16.7.0, react-is@^16.8.1:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
@@ -2114,19 +2116,19 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-richie-education@1.0.0-beta.8:
-  version "1.0.0-beta.8"
-  resolved "https://registry.yarnpkg.com/richie-education/-/richie-education-1.0.0-beta.8.tgz#e10897b7308d8f92290868720c11c860ff860ba8"
-  integrity sha512-zXqGwG6RMmoYtjiTdY0W1jbyquzks5ybd5pRZFuV1ip996dg9xgUGan8wPY1MGDqfls73QsQ7mklMIH+sCzZpw==
+richie-education@1.0.0-beta.9:
+  version "1.0.0-beta.9"
+  resolved "https://registry.yarnpkg.com/richie-education/-/richie-education-1.0.0-beta.9.tgz#d1f66e6bb790952a1f8e039d8fa867021ff10d54"
+  integrity sha512-OAD2u5e0l9oYe712/VBIHYjdvcrVOxuW7oLd/cvXpNUh74wAa2GOh0VqPE7rQqFi6fYuS5wlGBxWg70NY+aylw==
   dependencies:
     bootstrap "4.3.1"
     core-js "3"
     lodash-es "4.17.11"
-    query-string "6.4.2"
+    query-string "6.5.0"
     react "16.8.6"
     react-autosuggest "9.4.3"
     react-dom "16.8.6"
-    react-intl "2.8.0"
+    react-intl "2.9.0"
 
 rimraf@2, rimraf@^2.6.1:
   version "2.6.3"


### PR DESCRIPTION
### Added

- Replace DjangoCMS picture plugin by our simple picture plugin: only one
  field to upload the image, all attributes that control how the image is
  resized, cropped and displayed are now in the code,
- In the sandbox project, configure Django Filer to serve private files,
- Create a user group for each course and give it the permission to manage
  pages below the course (snapshots and course runs),
- Create a folder in Django Filer for each organization and for each course,
- When a new course is created for an organization, automatically associate
  permissions to organization admins (as defined in settings or with sensible
  defaults),
- Configure permission checks on page creations via the CMS wizard,
- Automatically create a page role and associate admin permissions when a new
  organization page is created (as defined in settings or with sensible
  defaults),
- Add page roles to link a user group to a CMS page, searchable via the admin,
- Add page roles to link a user group to a CMS page,
- Add a persons index and viewset to enable text queries and autocomplete
  requests on person names from the API.
- Index person names on courses to allow users to find courses when they
  type a related person's name in full text search.
- Add a persons filter to the course Search view and suggest persons in
  autocomplete search field.
- Add a management command to create the required site structure,
- Allow to dynamically set webpack publicPath. This is useful if a CDN is used
  to load statics. Define the settings `CDN_DOMAIN` and it will be used as base
  domain to fetch js chunks.

### Changed

- Restrict course content to plain text in standard sections,
- Change the order of placeholders on the course page following feedback from
  our support team,
- Simplify the Docker development stack to have a single `Dockerfile` and
  docker-compose configuration for testing either with MySQL or PostgreSQL
  database backend
- Standardize the project's `Makefile` to make it more easily maintainable by
  our peers
- Database ports are no longer exposed in the development environment

### Removed

- Alpine images are no longer maintained and have been removed from the project

### Fixed

- Fix production image by removing dependency to `factory` in production code,
- Fail and return a meaningful error when an invalid slug is submitted in
  page creation wizards,
- Fix person placeholders mistakenly showing on the organization page,
- Fix serializer that was failing for a course indexed with no organization,
- The language filter, which is not a drilldown filter, no longer behaves
  like one. Ditto for any future similar filters,
- All children are now shown when a parent filter value is "opened", instead
  of just the top 5 by facet count.
