### PR TITLE
🐛(settings) fix CDN_DOMAIN value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Define CDN_DOMAIN settings with cloudfront domain value.
+- Define CDN_DOMAIN setting from AWS CloudFront domain value
 
 ### Changed
 

--- a/src/backend/funmooc/settings.py
+++ b/src/backend/funmooc/settings.py
@@ -378,7 +378,12 @@ class Production(Base):
 
     AWS_CLOUDFRONT_DOMAIN = values.Value()
 
-    CDN_DOMAIN = AWS_CLOUDFRONT_DOMAIN
+    @property
+    def CDN_DOMAIN(self):
+        """CDN_DOMAIN is used to load frontend built chunks; it should match the AWS CloudFront
+        domain used as a CDN. As other configurations will inherit from this setting, it should
+        be lazily evaluated via the @property pattern."""
+        return self.AWS_CLOUDFRONT_DOMAIN
 
 
 class Feature(Production):


### PR DESCRIPTION
## Purpose

The `CDN_DOMAIN` setting is empty (at least in `Staging` environment).

## Proposal

We need to set the `CDN_DOMAIN `setting to the same value as the `AWS_CLOUDFRONT_DOMAIN` setting. Let's instantiate it from the environment instead.