### PR TITLE
Update fstream to safe version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Upgrade richie to 1.0.0
 
+### Security
+
+- Update `fstream` to a safe version (>=1.0.12)
+
 ## [0.2.0] - 2019-05-07
 
 ### Changed

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -703,10 +703,10 @@ fsevents@^1.2.7:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
 
-fstream@^1.0.0, fstream@^1.0.2:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
-  integrity sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=
+fstream@^1.0.0, fstream@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
+  integrity sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
   dependencies:
     graceful-fs "^4.1.2"
     inherits "~2.0.0"


### PR DESCRIPTION
## Purpose

We learned that versions of fstream below 1.0.12 are unsafe.

## Proposal

Since it is an indirect dependency, we can't update it in our package.json. We can however upgrade our lockfile to ensure we use the safe version.
This will be moot when we get a new version of Richie with updated dependencies but lets us fix the issue right now without needing a new Richie tag.