### PR TITLE
🔧(settings) configure X_FRAME_OPTIONS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Upgrade richie to 1.0.0
 
+### Fixed
+
+- Configure `X_FRAME_OPTIONS` to `SAMEORIGIN` to allow DjangoCMS frontend admin
+  frames display
+
 ### Security
 
 - Update `fstream` to a safe version (>=1.0.12)

--- a/src/backend/funmooc/settings.py
+++ b/src/backend/funmooc/settings.py
@@ -81,13 +81,7 @@ class Base(DRFMixin, RichieCoursesConfigurationMixin, Configuration):
 
     # Security
     ALLOWED_HOSTS = []
-    CSRF_COOKIE_SECURE = True
     SECRET_KEY = values.Value(None)
-    SECURE_BROWSER_XSS_FILTER = True
-    SECURE_CONTENT_TYPE_NOSNIFF = True
-    SESSION_COOKIE_SECURE = True
-    SILENCED_SYSTEM_CHECKS = values.ListValue([])
-    X_FRAME_OPTIONS = "DENY"
 
     # Application definition
     ROOT_URLCONF = "funmooc.urls"
@@ -346,7 +340,25 @@ class Production(Base):
     DJANGO_ALLOWED_HOSTS="foo.com,foo.fr"
     """
 
+    # Security
     ALLOWED_HOSTS = values.ListValue(None)
+    CSRF_COOKIE_SECURE = True
+    SECURE_BROWSER_XSS_FILTER = True
+    SECURE_CONTENT_TYPE_NOSNIFF = True
+    SESSION_COOKIE_SECURE = True
+    # System check reference:
+    # https://docs.djangoproject.com/en/2.2/ref/checks/#security
+    SILENCED_SYSTEM_CHECKS = values.ListValue(
+        [
+            # Allow the X_FRAME_OPTIONS to be set to "SAMEORIGIN"
+            "security.W019"
+        ]
+    )
+    # The X_FRAME_OPTIONS value should be set to "SAMEORIGIN" to display
+    # DjangoCMS frontend admin frames. Dockerflow raises a system check security
+    # warning with this setting, one should add "security.W019" to the
+    # SILENCED_SYSTEM_CHECKS setting (see above).
+    X_FRAME_OPTIONS = "SAMEORIGIN"
 
     DEFAULT_FILE_STORAGE = "funmooc.storage.MediaStorage"
 


### PR DESCRIPTION
## Purpose

The `X_FRAME_OPTIONS` setting should be set to `SAMEORIGIN` to allow DjangoCMS admin frames display; this requires to ignore a system check.

## Proposal

- [x] move security-related settings to the `Production` configuration
- [x] configure `X_FRAME_OPTIONS` to  `SAMEORIGIN` (and ignore related Django system check warning)

This is a backport from https://github.com/openfun/richie/pull/719