### PR TITLE
Upgrade richie to 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Upgrade richie to 1.0.0
+- Upgrade richie to 1.4.1
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ MANAGE_CI = $(COMPOSE_RUN_CI) python manage.py
 # -- Rules
 default: help
 
-bootstrap: env.d/aws data/media/.keep data/static/.keep build-front build run migrate ## install development dependencies
+bootstrap: env.d/aws data/media/.keep data/static/.keep build-front build run migrate init ## install development dependencies
 .PHONY: bootstrap
 
 # == Docker
@@ -98,11 +98,10 @@ collectstatic:  ## collect static files to /data/static
 	@$(MANAGE) collectstatic
 .PHONY: collectstatic
 
-demo-site: ## create a demo site
-	@$(MANAGE) flush
-	@$(MANAGE) create_demo_site
-	@${MAKE} search-index;
-.PHONY: demo-site
+init: ## create base site structure
+	@$(MANAGE) richie_init
+	@${MAKE} search-index
+.PHONY: init
 
 migrate: ## perform database migrations
 	@$(MANAGE) migrate

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,8 +3,8 @@ django-configurations==2.1
 # Superior versions of django-storages are not compatible with
 # ManifestStaticFilesStorage
 django-storages==1.6.3
-dockerflow==2018.4.0
+dockerflow==2019.6.0
 gunicorn==19.9.0
 psycopg2-binary==2.7.7
 richie==1.4.1
-sentry-sdk==0.7.9
+sentry-sdk==0.9.5

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,5 +6,5 @@ django-storages==1.6.3
 dockerflow==2018.4.0
 gunicorn==19.9.0
 psycopg2-binary==2.7.7
-richie==1.0.0
+richie==1.4.1
 sentry-sdk==0.7.9

--- a/src/backend/funmooc/settings.py
+++ b/src/backend/funmooc/settings.py
@@ -196,6 +196,7 @@ class Base(DRFMixin, RichieCoursesConfigurationMixin, Configuration):
         "richie.apps.core",
         "richie.apps.courses",
         "richie.apps.search",
+        "richie.plugins.html_sitemap",
         "richie.plugins.large_banner",
         "richie.plugins.plain_text",
         "richie.plugins.section",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -31,6 +31,6 @@
     "node-sass": "4.11.0",
     "nodemon": "1.18.10",
     "prettier": "1.16.4",
-    "richie-education": "1.0.0"
+    "richie-education": "1.4.1"
   }
 }

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -703,7 +703,7 @@ fsevents@^1.2.7:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
 
-fstream@^1.0.0, fstream@^1.0.12:
+fstream@^1.0.0, fstream@^1.0.2:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
   integrity sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
@@ -1891,10 +1891,10 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-query-string@6.5.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.5.0.tgz#2e1a70125af01f6f04573692d02c09302a1d8bfc"
-  integrity sha512-TYC4hDjZSvVxLMEucDMySkuAS9UIzSbAiYGyA9GWCjLKB8fQpviFbjd20fD7uejCDxZS+ftSdBKE6DS+xucJFg==
+query-string@6.8.1:
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.8.1.tgz#62c54a7ef37d01b538c8fd56f95740c81d438a26"
+  integrity sha512-g6y0Lbq10a5pPQpjlFuojfMfV1Pd2Jw9h75ypiYPPia3Gcq2rgkKiIwbkS6JxH7c5f5u/B/sB+d13PU+g1eu4Q==
   dependencies:
     decode-uri-component "^0.2.0"
     split-on-first "^1.0.0"
@@ -2116,15 +2116,15 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-richie-education@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/richie-education/-/richie-education-1.0.0.tgz#1cfd15d50b458d05f01fca21a5b69983944f10ff"
-  integrity sha512-IaBB5qzRefD1baMAVLSrrWepBmbwzClciZNOclfDtU2kI994gHYoTm7wuu8fzqLRLmTHlgiznr4kloXtMUabSA==
+richie-education@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/richie-education/-/richie-education-1.4.1.tgz#c8f6191ddd110e79dd36af01d8862a9776fc2fe5"
+  integrity sha512-GBSWjTi2e/HUTfPqkrTad0+muhPw3fbnupnsQ9c6qQM3ipK/UZa2/Bxi11hyqfdidU/yYkCkLpLGbb+DWurVdA==
   dependencies:
     bootstrap "4.3.1"
     core-js "3"
     lodash-es "4.17.11"
-    query-string "6.5.0"
+    query-string "6.8.1"
     react "16.8.6"
     react-autosuggest "9.4.3"
     react-dom "16.8.6"


### PR DESCRIPTION
## Purpose

We are a bit late on the party: we need to upgrade to the latest Richie release.

## Proposal

- [x] upgrade richie back & front to 1.4.1 release
- [x] update plugins settings
- [x] upgrade sentry & dockerflow