### PR TITLE
⬆️(core) upgrade to Richie 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Upgrade richie to 1.4.1
+- Upgrade richie to 1.5.0
 
 ### Fixed
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,5 +6,5 @@ django-storages==1.6.3
 dockerflow==2019.6.0
 gunicorn==19.9.0
 psycopg2-binary==2.7.7
-richie==1.4.1
+richie==1.5.0
 sentry-sdk==0.9.5

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -31,6 +31,6 @@
     "node-sass": "4.11.0",
     "nodemon": "1.18.10",
     "prettier": "1.16.4",
-    "richie-education": "1.4.1"
+    "richie-education": "1.5.0"
   }
 }

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -2116,10 +2116,10 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-richie-education@1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/richie-education/-/richie-education-1.4.1.tgz#c8f6191ddd110e79dd36af01d8862a9776fc2fe5"
-  integrity sha512-GBSWjTi2e/HUTfPqkrTad0+muhPw3fbnupnsQ9c6qQM3ipK/UZa2/Bxi11hyqfdidU/yYkCkLpLGbb+DWurVdA==
+richie-education@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/richie-education/-/richie-education-1.5.0.tgz#4529ac5e8e79c34736bacc30317bbe579b577a4f"
+  integrity sha512-NiFKGgjabETMaZ8MecLnhdXqHRzfky237LpsmS8RtmyvCx3yc2dD6qG2CsOUaeYdjRLOScAJC63iRJDzGJYyag==
   dependencies:
     bootstrap "4.3.1"
     core-js "3"


### PR DESCRIPTION
### Added

- Add a section "What you will learn" to the course page.

### Fixed

- Fix language confusion when getting objects that are related to a course via a plugin (organizations, categories and persons),
- Use empty image alt text & no link title text for course glimpses to comply with accessibility standards (existing alts & titles were redundant).
- Fix an issue that caused inconsistent UI and broken search results when selecting a suggestion in course search.