### PR TITLE
💩(permissions) disable unsorted uploads from Django filer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Disable the "unsorted uploads" directory on Django Filer,
 - Upgrade richie to 1.5.1.
 
 ### Security

--- a/src/backend/funmooc/core/admin.py
+++ b/src/backend/funmooc/core/admin.py
@@ -1,0 +1,21 @@
+"""Admin overrides for the fun-mooc site."""
+from django.http import JsonResponse
+from django.utils.translation import ugettext_lazy as _
+from django.views.decorators.csrf import csrf_exempt
+
+from filer.admin import clipboardadmin
+from filer.admin.clipboardadmin import ajax_upload as filer_ajax_upload
+from filer.models.virtualitems import FolderRoot
+
+
+@csrf_exempt
+def ajax_upload(request, folder_id=None):
+    """Disallow unsorted uploads."""
+    if folder_id is None:
+        return JsonResponse({"error": _("Unsorted uploads are not allowed.")})
+
+    return filer_ajax_upload(request, folder_id=folder_id)
+
+
+clipboardadmin.ajax_upload = ajax_upload
+FolderRoot.virtual_folders = lambda o: []


### PR DESCRIPTION
## Purpose

Django filer allows anyone to upload files to a default directory called `unsorted uploads`.

We want to force our users to upload their images to the right folder (on which we have given them upload rights).

## Proposal

[Django Filer](https://github.com/divio/django-filer) does not let us disable the `unsorted uploads` directory, so we use monkey patching to achieve this feature...
