### PR TITLE
✨(gimporter) create permissions on organizations and courses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Create roles and permissions for organizations and courses imported via the
+  Google sheet importer,
 - Import course licences from Google sheet fixtures.
 
 ### Changed

--- a/src/backend/funmooc/gimporter/import_scripts/organizations.py
+++ b/src/backend/funmooc/gimporter/import_scripts/organizations.py
@@ -52,11 +52,12 @@ def import_organizations(sheet):
             title_obj.title = title
             title_obj.save()
 
-        Organization.objects.update_or_create(
+        organization, _created = Organization.objects.update_or_create(
             extended_object__reverse_id=reverse_id,
             extended_object__publisher_is_draft=True,
             defaults={"extended_object": organization_page},
         )
+        organization.create_page_role()
 
         # Add a plugin for the description
         placeholder_description = organization_page.placeholders.get(slot="description")


### PR DESCRIPTION
### Purpose

After importing objects from a Google sheet, we must create the related roles and permissions.

### Proposal

Add calls to the existing helper methods for each organization and each course that are being created by the Google sheet importer.
