### PR TITLE
Fix search page behind htaccess

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,46 @@ jobs:
           name: Lint code with bandit
           command: ~/.local/bin/bandit -qr .
 
+  test-back:
+    docker:
+      - image: circleci/python:3.7-stretch
+        environment:
+          DJANGO_SETTINGS_MODULE: funmooc.settings
+          PYTHONPATH: /home/circleci/fun/src/backend
+          DJANGO_CONFIGURATION: Test
+          DJANGO_SECRET_KEY: ThisIsAnExampleKeyForTestPurposeOnly
+          DB_HOST: localhost
+          DB_NAME: funmooc
+          DB_USER: funmooc_user
+          DB_PASSWORD: pass
+          DB_PORT: 5432
+      - image: circleci/postgres:9.6-alpine-ram
+        environment:
+          POSTGRES_DB: funmooc
+          POSTGRES_USER: funmooc_user
+          POSTGRES_PASSWORD: pass
+    working_directory: ~/fun/src/backend
+    steps:
+      - checkout:
+          path: ~/fun
+      - restore_cache:
+          keys:
+            - v1-back-dependencies-{{ .Revision }}
+      # Run back-end (Django) test suite
+      #
+      # Nota bene: to run the django test suite, we need to ensure that the
+      # PostgreSQL service is up and ready. To achieve this,
+      # we wrap the command execution with dockerize, a tiny tool
+      # installed in the development image. In our case, dockerize will wait
+      # up to one minute until the database container is answering on port 5432.
+      - run:
+          name: Run tests
+          command: |
+                dockerize \
+                  -wait tcp://localhost:5432 \
+                  -timeout 60s \
+                    ~/.local/bin/pytest
+
   # ---- Front-end jobs ----
   build-front-production:
     docker:
@@ -315,6 +355,12 @@ workflows:
             tags:
               only: /.*/
       - lint-back:
+          requires:
+            - build-back
+          filters:
+            tags:
+              only: /.*/
+      - test-back:
           requires:
             - build-back
           filters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Upgrade richie to 1.9.1,
 - Make the superuser field readonly for non superusers.
 
+### Fixed
+
+- Make API calls work behind an htaccess by removing Basic Auth fallback.
+
 ## [0.4.3] - 2019-09-12
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,10 @@ lint-front-prettier-write: ## run prettier over scss files -- beware! overwrites
 	@$(YARN) prettier-write
 .PHONY: lint-front-prettier-write
 
+test-back: ## run back-end tests
+	bin/pytest
+.PHONY: test-back
+
 watch-sass: ## watch changes in Sass files
 	@$(YARN) watch-sass
 .PHONY: watch-sass

--- a/bin/pytest
+++ b/bin/pytest
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
+
+docker-compose run --rm \
+    -e DJANGO_CONFIGURATION=Test \
+    -e PYTHONPATH=/app \
+    app \
+    dockerize -wait "tcp://db:5432" -timeout 60s \
+        pytest "$@"

--- a/src/backend/funmooc/base/tests/test_settings.py
+++ b/src/backend/funmooc/base/tests/test_settings.py
@@ -1,0 +1,50 @@
+"""Test fun-mooc configuration."""
+from unittest import mock
+
+from django.conf import settings
+from django.test import TestCase, override_settings
+
+from rest_framework.response import Response
+from rest_framework.settings import DEFAULTS, api_settings
+from richie.apps.search.viewsets.courses import CoursesViewSet
+
+
+class ConfigurationTestCase(TestCase):
+    """Validate that our configuration works as expected."""
+
+    @mock.patch.object(CoursesViewSet, "list", spec=True, return_value=Response({}))
+    def test_configuration_restframework_htaccess(self, _mock_list):
+        """The search API endpoint should work behind an htaccess."""
+        # First, check that API calls were broken with the default DRF configuration
+        # What was happening is that DRF defines Basic Authentication as a fallback by default
+        # and our query has a basic auth header with the username and password of the htaccess
+        # defined in nginx. Django was trying to authenticate a user with these credentials,
+        # which of course failed.
+        with override_settings(
+            REST_FRAMEWORK={
+                **settings.REST_FRAMEWORK,
+                "DEFAULT_AUTHENTICATION_CLASSES": DEFAULTS[
+                    "DEFAULT_AUTHENTICATION_CLASSES"
+                ],
+            }
+        ):
+            authentication_classes = api_settings.DEFAULT_AUTHENTICATION_CLASSES
+
+        # The authentication classes are loaded before settings are overriden so we need
+        # to mock them on the APIView
+        with mock.patch(
+            "rest_framework.views.APIView.authentication_classes",
+            new_callable=mock.PropertyMock,
+            return_value=authentication_classes,
+        ):
+            response = self.client.get(
+                "/api/v1.0/courses/",
+                HTTP_AUTHORIZATION="Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
+            )
+        self.assertEqual(response.status_code, 403)
+
+        # Check that the project configuration solves it
+        response = self.client.get(
+            "/api/v1.0/courses/", HTTP_AUTHORIZATION="Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+        )
+        self.assertEqual(response.status_code, 200)

--- a/src/backend/funmooc/settings.py
+++ b/src/backend/funmooc/settings.py
@@ -49,6 +49,9 @@ class DRFMixin:
         "ALLOWED_VERSIONS": ("1.0",),
         "DEFAULT_VERSION": "1.0",
         "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.URLPathVersioning",
+        "DEFAULT_AUTHENTICATION_CLASSES": (
+            "rest_framework.authentication.SessionAuthentication",
+        ),
     }
 
 


### PR DESCRIPTION
## Purpose

The DRF API calls were responding with a 403 status code for anonymous users, and were working for authenticated users. This was due to a Basic Auth fallback option in the default configuration of DRF's authentication backends.

For an anonymous user:
- The first authentication backend in the list of DRF's default backends (Django session authentication) does not try to authenticate because it does not see any cookie,
- The second backend (Basic Authentication) tries to authenticate because it sees an Authentication header. But this header is coming from the Nginx htaccess (and is not known by Django), so the authentication fails with a 403.

Removing the Basic Authentication backend allows anonymous users to be really considered as anonymous in Django.

## Proposal

- Remove Basic Auth fallback option from DRF's authentication backends,
- Add pipework to run tests via make and in the CI,
- Add a test to validate that the site now works behind an htaccess.

Another alternative would have been that nginx does not pass the Basic Authentication headers. This can be done in [arnold](https://github.com/openfun/arnold) but we also don't want to allow basic authentication on our site so it had to be removed here as well.

