### PR TITLE
💄(large_banner) adjust image background size for hero-intro variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Correctly adjust hero-intro background to homepage mockup.
+
 ## [0.9.2] - 2020-05-07
 
 ### Fixed

--- a/src/frontend/scss/_main.scss
+++ b/src/frontend/scss/_main.scss
@@ -75,7 +75,7 @@
 @import 'richie-education/scss/components/templates/courses/plugins/category_plugin';
 @import 'richie-education/scss/components/templates/courses/plugins/licence_plugin';
 @import './components/templates/richie/section/section';
-@import 'richie-education/scss/components/templates/richie/large_banner/large_banner';
+@import './components/templates/richie/large_banner/large_banner';
 @import 'richie-education/scss/components/templates/richie/nesteditem/nesteditem';
 @import 'richie-education/scss/components/templates/richie/glimpse/glimpse';
 

--- a/src/frontend/scss/components/templates/richie/large_banner/_large_banner.scss
+++ b/src/frontend/scss/components/templates/richie/large_banner/_large_banner.scss
@@ -1,0 +1,17 @@
+@import 'richie-education/scss/components/templates/richie/large_banner/large_banner';
+
+.hero-intro {
+  // NOTE: Adjust background size on large screens so image fit more nicely
+  background-size: cover;
+  @include media-breakpoint-up(md) {
+    background-size: auto;
+  }
+
+  &__inner {
+    // NOTE: Remove white transparent mask on large screen so image is more
+    // visible but keep it for small screen to ensure text readability
+    @include media-breakpoint-up(md) {
+      background: transparent;
+    }
+  }
+}

--- a/src/frontend/scss/settings/_colors.scss
+++ b/src/frontend/scss/settings/_colors.scss
@@ -218,9 +218,9 @@ $r-theme: (
     white-mask-gradient: $white-mask-gradient,
   ),
   topbar: (
-    base-background: r-color('white'),
-    over-background: rgba(r-color('white'), 0.1),
-    over-border: r-color('light-grey'),
+    base-background: null,
+    over-background: null,
+    over-border: rgba(r-color('light-grey'), 0.5),
     hamburger-color: r-color('ocean-blue'),
     item-color: r-color('black'),
     item-hover-color: r-color('darkish-blue'),


### PR DESCRIPTION
In fun-mooc mockup, the background image in hero intro on homepage is
clearly visible without cropping it.

This commit remove transparent white mask over hero background and let
the image take the full size on large screens.