### PR TITLE
Let CloudFront forward the Authorization headers to make it work when htaccess is activated

### DIFF
--- a/src/aws/cloudfront.tf
+++ b/src/aws/cloudfront.tf
@@ -66,7 +66,7 @@ resource "aws_cloudfront_distribution" "funmooc_cloudfront_distribution" {
 
     forwarded_values {
       query_string = false
-      headers = ["Access-Control-Request-Headers", "Access-Control-Request-Method", "Origin"]
+      headers = ["Access-Control-Request-Headers", "Access-Control-Request-Method", "Authorization", "Origin"]
 
       cookies {
         forward = "none"
@@ -89,7 +89,7 @@ resource "aws_cloudfront_distribution" "funmooc_cloudfront_distribution" {
 
     forwarded_values {
       query_string = false
-      headers = ["Access-Control-Request-Headers", "Access-Control-Request-Method", "Origin"]
+      headers = ["Access-Control-Request-Headers", "Access-Control-Request-Method", "Authorization", "Origin"]
 
       cookies {
         forward = "none"

--- a/src/aws/variables.tf
+++ b/src/aws/variables.tf
@@ -26,7 +26,7 @@ variable "app_domain" {
   type = "map"
 
   default = {
-    production = "www.fun-mooc.fr"
+    production = "new.fun-mooc.fr"
     preprod = "preprod.fun.oc.openfun.fr"
     staging = "staging.fun.oc.openfun.fr"
   }

--- a/src/backend/funmooc/settings.py
+++ b/src/backend/funmooc/settings.py
@@ -504,7 +504,6 @@ class Feature(Production):
     nota bene: it should inherit from the Production environment.
     """
 
-    AWS_STATIC_BUCKET_NAME = values.Value("feature-funmooc-static")
     AWS_MEDIA_BUCKET_NAME = values.Value("feature-funmooc-media")
 
 


### PR DESCRIPTION
## Purpose

Static files could not be served via CloudFront. They were blocked by htaccess without any possibility to login because `Authorization` headers were not forwarded by CloudFront.

## Proposal

Forward the `Authorization` header.